### PR TITLE
Make Rofi DPI aware

### DIFF
--- a/configuration/apps.lua
+++ b/configuration/apps.lua
@@ -1,11 +1,13 @@
 local filesystem = require('gears.filesystem')
+local with_dpi = require('beautiful').xresources.apply_dpi
+local get_dpi = require('beautiful').xresources.get_dpi
 
 return {
   -- List of apps to start by default on some actions
   default = {
     terminal = 'alacritty',
     editor = 'code',
-    rofi = 'rofi -show drun -theme ' .. filesystem.get_configuration_dir() .. '/configuration/rofi.rasi',
+    rofi = 'rofi -dpi ' .. get_dpi() .. ' -width ' .. with_dpi(400) .. ' -show drun -theme ' .. filesystem.get_configuration_dir() .. '/configuration/rofi.rasi',
     lock = 'i3lock-fancy-rapid 5 3 -k --timecolor=ffffffff --datecolor=ffffffff',
     quake = 'alacritty --title QuakeTerminal'
   },

--- a/configuration/rofi.rasi
+++ b/configuration/rofi.rasi
@@ -47,7 +47,6 @@ window {
 	anchor:		 west;
 	x-offset: 0px;
 	height:		 100%;
-	width:		 400px;
 	margin-right: 60px;
 	orientation: horizontal;
 	children:	 [mainbox];


### PR DESCRIPTION
This patch makes Rofi aware of DPI changes. The benefit of this is that you do not have to manually edit `rofi.rasi` to adjust its width when updating your DPI settings.
